### PR TITLE
Small nits & comments on the PEP

### DIFF
--- a/pep.rst
+++ b/pep.rst
@@ -29,6 +29,7 @@ with the ability to process the literal string and embedded values:
 Tag functions accept prepared arguments and return a string:
 
 .. code-block:: python
+
     def greet(*args):
         salutation, recipient, *_ = args
         _, getvalue = recipient
@@ -167,7 +168,7 @@ Here is a more generalized version using structural pattern matching and type hi
         for arg in args:
             match arg:
                 case Decoded() as decoded:
-                    result.append(arg)
+                    result.append(decoded)
                 case Interpolation() as interpolation:
                     value = interpolation.getvalue()
                     result.append(value.upper())
@@ -202,7 +203,7 @@ provide Python string formatting info, as well as the original text:
     name = "World"
     assert greet"Hello {name!r:s}" == "Hello gv: World, r: name, c: r, f: s!"
 
-You can see each ``Interpolation`` parts getting extracted:
+You can see each of the ``Interpolation`` parts getting extracted:
 
 - The lambda expression to call and get the value in the scope it was defined
 - The raw string of the interpolation (``name``)
@@ -467,13 +468,13 @@ Tag strings desugar as follows:
 
 .. code-block:: python
 
-    mytag'Hi, {name}!'
+    mytag'Hi, {name!s:format_spec}!'
 
 This is equivalent to:
 
 .. code-block:: python
 
-    mytag('Hi, ', (lambda: name, 'name', None, None), '!')
+    mytag('Hi, ', (lambda: name, 'name', 's', 'format_spec'), '!')
 
 Tag Function Names are in the Same Namespace
 --------------------------------------------


### PR DESCRIPTION
Comments:

- Section `Tag Function Names are in the Same Namespace`: I'm not sure what value the paragraph about f-string prefixes and soft keywords adds. It talks about a tag function named `f`, which is not valid in the first place. Maybe I'm missing something?
- Maybe remove the `Performance` before we go public section if we don't have something more concrete? It raises more questions than it answers.
- I think we need to talk about the format spec being eagerly evaluated in the `Specification`. Every time I went through the document I felt that that being specified came a bit too late.
- Maybe also add to the `Specification` the part about the `=` sign? It seems like this came a bit later too.
- Should we add examples that do not return strings but an arbitrary other type? This seems like one of the things that'll spark the most controversy and we probably want to be upfront about it.